### PR TITLE
Strings length issue.

### DIFF
--- a/string-rotation/index.js
+++ b/string-rotation/index.js
@@ -1,3 +1,5 @@
 var stringRotation = function (a, b) {
+  if (a.length != b.length)
+    return false;
   return (a + a).indexOf(b) > -1;
 };


### PR DESCRIPTION
The function returns "true" even if the second string is not a rotation to the first one.
example: "School" "chool"
fix: check if the two strings are the same length.
