### PR TITLE
added overflow test for Node.js solution to Stack-Machine, currently fails

### DIFF
--- a/stack-machine/stack-machine.js
+++ b/stack-machine/stack-machine.js
@@ -1,4 +1,4 @@
-function solution (S) {
+exports.solution = function (S) {
   var stack = [];
 
   var requires = function (fn) {

--- a/test/stack-machine.js
+++ b/test/stack-machine.js
@@ -1,0 +1,20 @@
+var stackMachine = require('../stack-machine/stack-machine'),
+    assert       = require('assert');
+
+describe('stackMachine', function () {
+  it('should return -1 when 12-bit stack-machine overflows', function () {
+    // 12-bit unsigned integers range from 0 to 4095, anything higher is overflow
+
+    // 65 * 64 + 1 = 4095 + 1 = 4096 > 4095
+    assert.equal(stackMachine.solution('88*1+97**1+'), -1);
+
+    // 4095 + 4095 = 8190 > 4095
+    assert.equal(stackMachine.solution('88*1+97**88*1+97**+'), -1);
+
+    // 64 * 64 = 4096 > 4095
+    assert.equal(stackMachine.solution('88*88**'), -1);
+
+    // 4095 * 4095 = 16769025 > 4095
+    assert.equal(stackMachine.solution('88*1+97**88*1+97***'), -1);
+  });
+});


### PR DESCRIPTION
While coding #61, I came up with a few test inputs for 12-bit overflow to check it's handled correctly. So I went ahead and added them for the included Node.js stack-machine implementation. This involved a minor change so the test could access the solution.
