### PR TITLE
binary search tree check

### DIFF
--- a/binary-search-tree-check/binary-search-tree-check-alt.js
+++ b/binary-search-tree-check/binary-search-tree-check-alt.js
@@ -23,5 +23,4 @@ var isBinarySeachTree = function(bst) {
     return true;
 
   })(bst);
-
 };


### PR DESCRIPTION
I think the current implementation of the [binary search tree check](https://github.com/blakeembrey/code-problems/blob/master/binary-search-tree-check/binary-search-tree-check.js) is broken.

Haven't spent enough time to pinpoint the exact problem but [line 7](https://github.com/blakeembrey/code-problems/blob/master/binary-search-tree-check/binary-search-tree-check.js#L7) sticks out to me as in a correct BST, the right value will always be greater than the current value.

I've implemented an approach that I prefer, which checks the current node's value against the previously checked node.
