### PR TITLE
Fix bug in largest-continous-sequence.py

### DIFF
--- a/solutions/python/array-pair-sum.py
+++ b/solutions/python/array-pair-sum.py
@@ -1,5 +1,3 @@
-import unittest
-
 """solution to the array pair sum problem"""
 
 def array_pair_sum_iterative(arr, k):
@@ -51,33 +49,3 @@ def array_pair_sum_hash_table(arr, k):
     result.reverse()
 
     return result
-
-
-# Unit tests
-class array_pair_sum_tests(unittest.TestCase):
-
-    def setUp(self):
-        self.arr1 = [3, 4, 5, 6, 7]
-        self.arr2 = [3, 4, 5, 4, 4]
-        self.result1 = [[3, 7], [4, 6]]
-        self.result2 = [[3, 5], [4, 4], [4, 4], [4, 4]]
-
-    def test_one(self):
-        self.assertEqual(
-            array_pair_sum_iterative(self.arr1, 10), self.result1)
-        self.assertEqual(
-            array_pair_sum_sort(self.arr1, 10), self.result1)
-        self.assertEqual(
-            array_pair_sum_hash_table(self.arr1, 10), self.result1)
-
-    def test_two(self):
-        self.assertEqual(
-            array_pair_sum_iterative(self.arr2, 8), self.result2)
-        self.assertEqual(
-            array_pair_sum_sort(self.arr2, 8), self.result2)
-        self.assertEqual(
-            array_pair_sum_hash_table(self.arr2, 8), self.result2)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/solutions/python/largest-continuous-sum.py
+++ b/solutions/python/largest-continuous-sum.py
@@ -1,4 +1,3 @@
-import unittest
 """solution to the largest-continuous-sum problem"""
 
 def largest_continuous_sum(arr):
@@ -14,17 +13,3 @@ def largest_continuous_sum(arr):
             largest = sum
         last = num
     return largest
-
-class LargestContinousSequenceTest(unittest.TestCase):
-    def test_largest_continuous_sum(self):
-        sum = largest_continuous_sum([1, 2, 3, 4])
-        self.assertEqual(sum, 10)
-
-        sum = largest_continuous_sum([1, 2, 3, 1, 2, 3, 4])
-        self.assertEqual(sum, 10)
-
-        sum = largest_continuous_sum([1, 2, 3, 2, 5, 4])
-        self.assertEqual(sum, 6)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/python/array-pair-sum.py
+++ b/tests/python/array-pair-sum.py
@@ -1,0 +1,30 @@
+import unittest
+
+# Unit tests
+class array_pair_sum_tests(unittest.TestCase):
+
+    def setUp(self):
+        self.arr1 = [3, 4, 5, 6, 7]
+        self.arr2 = [3, 4, 5, 4, 4]
+        self.result1 = [[3, 7], [4, 6]]
+        self.result2 = [[3, 5], [4, 4], [4, 4], [4, 4]]
+
+    def test_one(self):
+        self.assertEqual(
+            array_pair_sum_iterative(self.arr1, 10), self.result1)
+        self.assertEqual(
+            array_pair_sum_sort(self.arr1, 10), self.result1)
+        self.assertEqual(
+            array_pair_sum_hash_table(self.arr1, 10), self.result1)
+
+    def test_two(self):
+        self.assertEqual(
+            array_pair_sum_iterative(self.arr2, 8), self.result2)
+        self.assertEqual(
+            array_pair_sum_sort(self.arr2, 8), self.result2)
+        self.assertEqual(
+            array_pair_sum_hash_table(self.arr2, 8), self.result2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/largest-continuous-sum.py
+++ b/tests/python/largest-continuous-sum.py
@@ -1,0 +1,15 @@
+import unittest
+
+class LargestContinousSequenceTest(unittest.TestCase):
+    def test_largest_continuous_sum(self):
+        sum = largest_continuous_sum([1, 2, 3, 4])
+        self.assertEqual(sum, 10)
+
+        sum = largest_continuous_sum([1, 2, 3, 1, 2, 3, 4])
+        self.assertEqual(sum, 10)
+
+        sum = largest_continuous_sum([1, 2, 3, 2, 5, 4])
+        self.assertEqual(sum, 6)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Rather obvious bug... When the largest sequence was at the end of `arr` it would be missed

`0 == largest_continuous_sum([1, 2, 3, 4])`
