### PR TITLE
improve the byte-format.js: using math instead of loop and condition.

### DIFF
--- a/solutions/javascript/byte-format.js
+++ b/solutions/javascript/byte-format.js
@@ -1,16 +1,9 @@
 module.exports = function (value, precision) {
   var suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   var factor   = Math.pow(10, precision > 0 ? precision : 2);
-  var suffix   = 0;
-
-  while (value >= 1024 && suffixes[++suffix] && suffix < suffixes.length) {
-    value /= 1024;
-  }
-
-  if (suffix >= suffixes.length) {
-    suffix = suffixes.length - 1;
-  }
-
-  // Return the number rounded to precision.
-  return (Math.round(value * factor) / factor) + ' ' + suffixes[suffix];
+  var suffix=Math.min (Math.floor(Math.log(value)/Math.log(1024)),
+    suffixes.length-1);
+  return (Math.round(value/Math.pow(1024,suffix) * factor)  / factor) +
+  ' ' +
+  suffixes[suffix];
 };


### PR DESCRIPTION
No more ___while___ and ___if___ workflow control. 

Using math.

reference:
[PHP code](http://stackoverflow.com/questions/2510434/format-bytes-to-kilobytes-megabytes-gigabytes)
[JavaScript](http://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript)