### PR TITLE
Add tests for array pair sum and a working solution.

### DIFF
--- a/solutions/javascript/array-pair-sum.js
+++ b/solutions/javascript/array-pair-sum.js
@@ -1,20 +1,13 @@
-module.exports = function (k, array) {
-  var hash  = {},
-      pairs = [];
+module.exports = function (sum, array) {
+  var results = [];
 
-  // Loop through the array once, storing the results in an object for a
-  // time complexity of O(n) - the naive solution consists of two for loops
-  // which results in a complexity of O(n^2)
-  array.forEach(function (number) {
-    // Make sure the value in unused and it's a unique pair
-    if (hash[k - number] === false && k - number !== number) {
-      pairs.push([number, k - number]);
-      hash[k - number] = true; // Set it to "used"
+  for (var i = 0, len = array.length; i < len; i++) {
+    for (var j = i + 1; j < len; j++) {
+      if (array[i] + array[j] === sum) {
+        results.push([array[i], array[j]]);
+      }
     }
+  }
 
-    // If the hash value is not true, set the hash to "unused"
-    !hash[k - number] && (hash[number] = false);
-  });
-
-  return pairs;
+  return results;
 };

--- a/tests/javascript/array-pair-sum.js
+++ b/tests/javascript/array-pair-sum.js
@@ -1,0 +1,12 @@
+var expect       = require('chai').expect;
+var arrayPairSum = require('../../solutions/javascript/array-pair-sum');
+
+describe('Array Pair Sum', function () {
+  it('should find pairs that equal the expected sum', function () {
+    expect(arrayPairSum(10, [3, 4, 5, 6, 7])).to.eql([[3, 7], [4, 6]]);
+  });
+
+  it('should allow for duplicate results', function () {
+    expect(arrayPairSum(8, [3, 4, 5, 4, 4])).to.eql([[3, 5], [4, 4], [4, 4], [4, 4]]);
+  });
+});


### PR DESCRIPTION
The previous solution didn’t allow for duplicate results so it didn’t
work as expected by the second test. This solution works with both
tests and does so very quickly at ~1.4M ops/sec
(http://jsperf.com/array-pair-sums).