### PR TITLE
Shorter shortest-fizz-buzz for Python{2,3}

### DIFF
--- a/solutions/python/shortest-fizz-buzz.py
+++ b/solutions/python/shortest-fizz-buzz.py
@@ -1,12 +1,4 @@
-def shortest_fizz_buz():
-    for i in xrange(0, 100):
-        s = ''
-        ss = False
-        if ((i + 1) % 3 == 0):
-            s +='Fizz'
-        if ((i + 1) % 5 == 0):
-            s +='Buzz'
-        if ((i + 1) % 3 > 0 and (i + 1) % 5 > 0):
-            print(i + 1)
-        else:
-            print(s)
+for i in range(1,101):
+ o=''if i%3else'Fizz'
+ if i%5==0:o+='Buzz'
+ print(o if o else i)


### PR DESCRIPTION
The solution for the shortest-fizz-buzz problem as it stands is not really that short at all even though that is the intended goal of the problem.

I propose the following as a solution. It works in both Python2 and Python3 and is significantly smaller (87 vs 305 characters).

This solution uses various tricks dependent on the way Python interprets code. In particular:
* Numbers cannot be ended by letters as per the lexer, so we are able to remove the space between `3` and `else`.
* We can put the bodies of `if` statements on the same line.
* There is no reason to check if something is both divisible by 3 and 5 if we order the checks appropriately and simply concatenate `'Buzz'` onto a result string.
* We can use whatever number of spaces we would like to delineate scopes.
* Python does automatic conversions to boolean values.