### PR TITLE
TravisCI integration for javascript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: node_js
 node_js:
   - "node"
+
+git:
+  submodules: false
+
 before_script:
   - npm install
+
 script:
   - npm test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "node"
+before_script:
+  - npm install
+script:
+  - npm test
+

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ This is my repo full of code problems that I have completed prior to or during a
 * [Shortest Fizz Buzz](https://github.com/blakeembrey/code-problems/tree/master/problems/shortest-fizz-buzz)
 
 ## Javascript Tests
+[![Build Status](https://travis-ci.org/SpiralOutDotEu/code-problems.svg?branch=master)](https://travis-ci.org/SpiralOutDotEu/code-problems)
 
 ```sh
 npm install # Installs `mocha` and any other dependencies needed to run

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ This is my repo full of code problems that I have completed prior to or during a
 
 * [Shortest Fizz Buzz](https://github.com/blakeembrey/code-problems/tree/master/problems/shortest-fizz-buzz)
 
-## Tests
+## Javascript Tests
 
 ```sh
 npm install # Installs `mocha` and any other dependencies needed to run


### PR DESCRIPTION
Added TravisCI integration for Javascript tests.
In order to work, you have to enable Travis to your repo and change the build status icon link to your repo
(https://travis-ci.org/SpiralOutDotEu/code-problems.svg?branch=master) ==> (https://travis-ci.org/blakeembrey/code-problems.svg?branch=master)